### PR TITLE
Introduced a macro variable "silent"

### DIFF
--- a/rateprogram/rateberegninger.sas
+++ b/rateprogram/rateberegninger.sas
@@ -173,7 +173,8 @@ run;
 %definere_aar;
 %definere_format;
 
-
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
+%if &silent=0 %then %do;
 title "Aldersstruktur for snitt i perioden (&min_aar-&max_aar), Andeler for &boomraadeN, Rater for &boomraade";
 PROC TABULATE DATA=NORGE_AGG_SNITT;	
 	VAR N_RV N_Innbyggere;
@@ -182,8 +183,9 @@ PROC TABULATE DATA=NORGE_AGG_SNITT;
 	N_RV={LABEL="&ratevariabel"}*(Sum={LABEL="&forbruksmal"}*F=&talltabformat..0 ColPctSum={LABEL="Andel (%)"}*F=&talltabformat2..1*{STYLE={JUST=CENTER}}) 
 	N_Innbyggere={LABEL="Innbyggere"}*(Sum={LABEL="Antall"}*F=&talltabformat..0 ColPctSum={LABEL="Andel (%)"}*F=&talltabformat2..1*{STYLE={JUST=CENTER}})
 	/ BOX={LABEL="Alderskategorier"};
-RUN; Title;
-
+RUN; 
+Title;
+%end;
 
 
 %if %sysevalf(%superq(aarsvarfigur)=,boolean) %then %let aarsvarfigur = 1;

--- a/rateprogram/sas/aldersfigur.sas
+++ b/rateprogram/sas/aldersfigur.sas
@@ -1,9 +1,9 @@
 
 %macro aldersfigur(data =, aarstall =);
 /*!
-Makro for Ã¥ lage aldersstruktur-figur over utvalget.
+Makro for å lage aldersstruktur-figur over utvalget.
 
-For Ã¥ lett kunne se om alderssammensetningen gir mening.
+For å lett kunne se om alderssammensetningen gir mening.
 */
 %local data;
 %local fontst;
@@ -27,6 +27,8 @@ PROC SQL;
       GROUP BY aar, Alder, ErMann;	  
 QUIT;
 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
+%if &silent=0 %then %do;
 proc sgplot data=tmp_aldersfig noautolegend noborder sganno=anno pad=(Bottom=4% );
 styleattrs datacolors=(CX00509E CX95BDE6) DATACONTRASTCOLORS=(CX00509E);
 	vbar alder / response=RV stat=mean group=ermann groupdisplay=cluster name="Vbar";
@@ -35,5 +37,6 @@ styleattrs datacolors=(CX00509E CX95BDE6) DATACONTRASTCOLORS=(CX00509E);
 		labelattrs=(size=&fontst)  valuesformat=&yformat. valueattrs=(size=&fontst);
 	xaxis &xvalues fitpolicy=thin offsetmin=0.035 label='Alder' labelattrs=(size=&fontst) valuesformat=&yformat. valueattrs=(size=&fontst);
 run;
+%end;
 
 %mend;

--- a/rateprogram/sas/definerVariabler.sas
+++ b/rateprogram/sas/definerVariabler.sas
@@ -123,4 +123,6 @@ Definere variabler
 
     %gi_verdi(variabel = SnittOmraade, verdi = Norge);
 
+    %gi_verdi(variabel = silent, verdi = 1);
+
 %mend;

--- a/rateprogram/sas/lag_aarsvarbilde.sas
+++ b/rateprogram/sas/lag_aarsvarbilde.sas
@@ -44,6 +44,7 @@
 
 %if %sysevalf(%superq(kolonneTo)=,boolean) %then %let kolonneTo = Innbyggere;
 %if %sysevalf(%superq(figurnavn)=,boolean) %then %let figurnavn = AA_&RV_variabelnavn._&bo; 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
 proc sql;
 create table aldersspenn as
@@ -130,7 +131,7 @@ run;
 
 
 %if &NorgeSoyle=0 %then %do;
-
+%if &silent=0 %then %do;
 /*ods graphics on;*/
 ODS Graphics ON /reset=All imagename="&figurnavn" imagefmt=&bildeformat  border=off HEIGHT=&hoyde width=&bredde;
 ODS Listing style=stil_figur Image_dpi=300 GPATH=&lagring;
@@ -160,6 +161,7 @@ hbarparm category=&bo response=rateSnitt / fillattrs=(color=CX95BDE6);
 	 	/ position=bottomright textattrs=(size=7);
 run;Title; ods listing close; /*ods graphics off;*/
 %end;
+%end;
 
 /*Alternativ årsvariasjonsfigur*/
 %if &NorgeSoyle=1 %then %do;
@@ -187,6 +189,7 @@ proc sort data=&bo._aarsvar;
 by descending rateSnitt;
 run;
 
+%if &silent=0 %then %do;
 ODS Graphics ON /reset=All imagename="&figurnavn" imagefmt=&bildeformat  border=off HEIGHT=&hoyde width=&bredde;
 ODS Listing style=stil_figur Image_dpi=300 GPATH=&lagring;
 title;
@@ -216,7 +219,7 @@ hbarparm category=&bo response=Snittrate / fillattrs=(color=CXC3C3C3);
           / position=bottomright textattrs=(size=7);
 %end;
 run;Title; ods listing close;
-
+%end;
 
 %end;
 

--- a/rateprogram/sas/lag_aarsvarfigur.sas
+++ b/rateprogram/sas/lag_aarsvarfigur.sas
@@ -129,8 +129,10 @@ proc sort data=&bo._aarsvar;
 by descending rateSnitt;
 run;
 
-%if &NorgeSoyle=0 %then %do;
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
+%if &NorgeSoyle=0 %then %do;
+%if &silent=0 %then %do;
 /*ods graphics on;*/
 ods listing style=stil_figur gpath="%sysfunc(getoption(work))";
 title "&standard rater pr &rate_pr innbyggere, &ratevariabel, &bo, &Min_alder - &Max_alder år, &min_aar - &max_aar";
@@ -159,6 +161,7 @@ hbarparm category=&bo response=rateSnitt / fillattrs=(color=CX95BDE6);
 	 	/ position=bottomright textattrs=(size=7);
 run;Title; ods listing close; /*ods graphics off;*/
 %end;
+%end;
 
 /*Alternativ årsvariasjonsfigur*/
 %if &NorgeSoyle=1 %then %do;
@@ -176,6 +179,7 @@ proc sort data=&bo._aarsvar;
 by descending rateSnitt;
 run;
 
+%if &silent=0 %then %do;
 ods listing style=stil_figur gpath="%sysfunc(getoption(work))";
 title "&standard rater pr &rate_pr innbyggere, &ratevariabel, &bo, &Min_alder - &Max_alder år, &min_aar - &max_aar";
 proc sgplot data=&bo._aarsvar noborder noautolegend sganno=anno pad=(Bottom=5%);
@@ -204,7 +208,7 @@ hbarparm category=&bo response=Snittrate / fillattrs=(color=CXC3C3C3);
           / position=bottomright textattrs=(size=7);
 %end;
 run;Title; ods listing close;
-
+%end;
 %end;
 
 %mend lag_aarsvarfigur;

--- a/rateprogram/sas/lag_kart.sas
+++ b/rateprogram/sas/lag_kart.sas
@@ -111,6 +111,9 @@ run;
 quit;
 Title; %end;*/
 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
+%if &silent=0 %then %do;
+
 goptions reset=pattern;
 %if &bo=BoRHF %then %do;
 title "Kart &Bo, &standard rater, &ratevariabel, &Min_alder - &Max_alder år, Snitt for perioden";
@@ -144,6 +147,8 @@ label RV_just_rate_sum='Rate';
 run;
 quit;
 Title;
+%end;
+
 %end;
 
 %mend lag_kart;

--- a/rateprogram/sas/print_info.sas
+++ b/rateprogram/sas/print_info.sas
@@ -1,7 +1,5 @@
 %macro print_info();
 
-%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
-%if &silent=0 %then %do;
 options nodate;
 data _null_;
 call symput ('timenow',put (time(),hhmm.));
@@ -19,6 +17,5 @@ ods text=" ";
 ods text="Periode: &Start≈r - &Slutt≈r";
 ods text="Aldersspenn: '&aldersspenn.'";
 ods text="Alderskategorier: '&Alderskategorier.'";
-%end;
 
 %mend;

--- a/rateprogram/sas/print_info.sas
+++ b/rateprogram/sas/print_info.sas
@@ -1,5 +1,7 @@
 %macro print_info();
 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
+%if &silent=0 %then %do;
 options nodate;
 data _null_;
 call symput ('timenow',put (time(),hhmm.));
@@ -17,5 +19,6 @@ ods text=" ";
 ods text="Periode: &Start≈r - &Slutt≈r";
 ods text="Aldersspenn: '&aldersspenn.'";
 ods text="Alderskategorier: '&Alderskategorier.'";
+%end;
 
 %mend;

--- a/rateprogram/sas/tabeller.sas
+++ b/rateprogram/sas/tabeller.sas
@@ -18,6 +18,7 @@ Created new macro, lag_tabeller, to make the appropriate tabeller based on "vis_
 
 
 */
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
 /*finn min og max alder*/
 /*finn min og max alder*/
@@ -42,7 +43,9 @@ PROC TABULATE DATA=&Bo._Agg_Rate out=norgesnitt;
 		sum=' '*(RV_just_rate="&standard rater"*Format=&talltabformat..&rateformat 
 		Ant_Opphold="&forbruksmal"*Format=&talltabformat..0 Ant_Innbyggere='Antall innbyggere'*Format=&talltabformat..0)
 		/BOX={LABEL="&SnittOmraade" STYLE={JUST=LEFT VJUST=BOTTOM}} MISSTEXT='none';
+%if &silent=0 %then %do;
 		Title "&standard rater pr &rate_pr innbyggere, &ratevariabel, &Min_alder - &Max_alder år, &SnittOmraade";
+%end;
 RUN;
 
 data norgesnitt;
@@ -60,7 +63,9 @@ PROC TABULATE DATA=&Bo._Agg_Rate out=&bo._Fig;
 	TABLE &Bo=' ', sum=' '*(RV_just_rate="&standard rater"*Format=&talltabformat..&rateformat 
 	Ant_Opphold="&forbruksmal"*Format=&talltabformat..0 Ant_Innbyggere='Antall innbyggere'*Format=&talltabformat..0)*aar=' '
 	/BOX={LABEL="&Bo" STYLE={JUST=LEFT VJUST=BOTTOM}} MISSTEXT='none';
+%if &silent=0 %then %do;
 	Title "&standard rater pr &rate_pr innbyggere, &ratevariabel, &Min_alder - &Max_alder år, &Bo";
+%end;
 RUN;
 
 data HNsnitt;
@@ -94,6 +99,7 @@ Therefore tabell_1e is now obsolete.
 
 */
 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
 Data _null_;
 set aldersspenn;
@@ -101,6 +107,7 @@ call symput('Min_alder', trim(left(put(minalder,8.))));
 call symput('Max_alder', trim(left(put(maxalder,8.))));
 run;
 
+%if &silent=0 %then %do;
 PROC TABULATE
 DATA=&Bo._Agg_CV Format=&talltabformat..3;
 	VAR CV SCV OBV RCV;
@@ -110,6 +117,7 @@ DATA=&Bo._Agg_CV Format=&talltabformat..3;
 	/BOX={Label="CV - &Bo" STYLE={JUST=LEFT VJUST=BOTTOM}} MISSTEXT='none'	;	;
 		Title "Variasjonsmål &ratevariabel, &Min_alder - &Max_alder år, &Bo";
 RUN;
+%end;
 %mend tabell_cv;
 
 %macro Tabell_CVe;
@@ -124,6 +132,7 @@ RUN;
 
 */
 
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
 Data _null_;
 set aldersspenn;
@@ -131,6 +140,7 @@ call symput('Min_alder', trim(left(put(minalder,8.))));
 call symput('Max_alder', trim(left(put(maxalder,8.))));
 run;
 
+%if &silent=0 %then %do;
 PROC TABULATE DATA=&Bo._Agg_Rate;	
 	VAR Ant_Innbyggere Ant_Opphold RV_rate RV_just_rate SDJUSTRate KI_N_J KI_O_J;
 	CLASS aar /	ORDER=UNFORMATTED MISSING;
@@ -141,6 +151,7 @@ PROC TABULATE DATA=&Bo._Agg_Rate;
 		/BOX={LABEL="Rater - &SnittOmraade" STYLE={JUST=LEFT VJUST=BOTTOM}} MISSTEXT='none'	;	;
 		Title "&standard rater pr &rate_pr innbyggere, &Min_alder - &Max_alder år, &SnittOmraade";
 RUN;
+%end;
 %mend tabell_3N;
 
 %macro tabell_3Ne;
@@ -154,6 +165,7 @@ RUN;
 
 
 */
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
 Data _null_;
 set aldersspenn;
@@ -161,6 +173,7 @@ call symput('Min_alder', trim(left(put(minalder,8.))));
 call symput('Max_alder', trim(left(put(maxalder,8.))));
 run;
 
+%if &silent=0 %then %do;
 PROC TABULATE DATA=&Bo._Agg_Rate ;	
 	VAR Ant_Innbyggere Ant_Opphold RV_rate RV_just_rate SDJUSTRate KI_N_J KI_O_J;
 	CLASS &Bo /	ORDER=UNFORMATTED MISSING;
@@ -180,8 +193,10 @@ DATA=&Bo._Agg_CV Format=&talltabformat..3;
 	TABLE aar='',
 	mean=' '*(CV*Format=&talltabformat..3 SCV*Format=&talltabformat..3 OBV*Format=&talltabformat..3 RCV*Format=&talltabformat..3)
 	/BOX={Label="CV - &Bo" STYLE={JUST=LEFT VJUST=BOTTOM}} MISSTEXT='none'	;	;
+
 		Title "Variasjonsmål &ratevariabel, &Min_alder - &Max_alder år, &Bo";
 RUN;
+%end;
 %mend Tabell_3;
 
 %macro Tabell_3e;

--- a/rateprogram/sas/utvalgx.sas
+++ b/rateprogram/sas/utvalgx.sas
@@ -140,10 +140,12 @@ Definere komnr og bydel basert på bohf hvis datasettet mangler komnr og bydel
 	run;
 	
 /*Nytt pr 11/5-17 - Frank Olsen - tabeller for eksludering*/
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
+%if &silent=0 %then %do;
 %if &vis_ekskludering=1 %then %do;
     %ekskluderingstabeller(datasett = tmp1utvalgx);
 %end;
-
+%end;
 
 %forny_komnr(datasett = tmp1UTVALGX);
 	/*----------------------------*/

--- a/rateprogram/sas/utvalgx.sas
+++ b/rateprogram/sas/utvalgx.sas
@@ -78,8 +78,11 @@ Første makro som kjøres direkte i rateprogrammet
 */
 
 %if %sysevalf(%superq(aarsvarfigur)=,boolean) %then %let aarsvarfigur = 1;
+%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
 
+%if &silent=0 %then %do;
 %print_info;
+%end;
 
 %definere_aar;
 
@@ -140,11 +143,8 @@ Definere komnr og bydel basert på bohf hvis datasettet mangler komnr og bydel
 	run;
 	
 /*Nytt pr 11/5-17 - Frank Olsen - tabeller for eksludering*/
-%if %sysevalf(%superq(silent)=,boolean) %then %let silent = 0;
-%if &silent=0 %then %do;
 %if &vis_ekskludering=1 %then %do;
     %ekskluderingstabeller(datasett = tmp1utvalgx);
-%end;
 %end;
 
 %forny_komnr(datasett = tmp1UTVALGX);

--- a/rateprogram/tests/lagFasit.sas
+++ b/rateprogram/tests/lagFasit.sas
@@ -1,10 +1,19 @@
+/*!
+Kode for å lage referansedatasett til test av rateprogrammet
+
+Kjøres enten ved å kopiere denne koden inn i et SAS-prosjekt, eller
+ved å ta koden inn med 
+```
+%include "\\tos-sas-skde-01\SKDE_SAS\felleskoder\master\rateprogram\tests\lagFasit.sas";
+```
+*/
+
 %let branch = master;
 %let filbane=\\tos-sas-skde-01\SKDE_SAS\felleskoder\&branch;
 %include "&filbane\rateprogram\tests\makroer.sas";
 
 %testAnno(lagReferanse = 1);
 %testUtvalgx(lagReferanse = 1);
-%testOmraadeNorge(lagReferanse = 1);
 %testRateberegninger(lagReferanse = 1);
 
 /*
@@ -12,6 +21,5 @@ Tester datasettene vi nettopp har produsert
 */
 %testAnno(lagReferanse = 0);
 %testUtvalgx(lagReferanse = 0);
-%testOmraadeNorge(lagReferanse = 0);
 %testRateberegninger(lagReferanse = 0);
 


### PR DESCRIPTION
Will reduce the amount of information printed to
the Results panel. Tables from `tabell_1` are still
printed because `PROC TABULATE` is run with `out=`
argument (thus the table is also made into a dataset)