### PR TITLE
ta ut rader som kun er til formater

### DIFF
--- a/makroer/boomraader.sas
+++ b/makroer/boomraader.sas
@@ -2,17 +2,17 @@
 /*! 
 ### Beskrivelse
 
-Makro for Ã¥ lage bo-variablene: boshhn, bohf, borhf og fylke.
-Bo-variablene defineres ved Ã¥ bruke 'komnr' og 'bydel' fra inndata.
+Makro for å lage bo-variablene: boshhn, bohf, borhf og fylke.
+Bo-variablene defineres ved å bruke 'komnr' og 'bydel' fra inndata.
 
 ```
 %boomraader(inndata=, indreOslo = 0, bydel = 1);
 ```
 
 ### Input 
-- inndata: Datasett som skal fÃ¥ koblet pÃ¥ bo-variablene.
-- indreOslo = 1: SlÃ¥r sammen Diakonhjemmet og Lovisenberg, NB: mÃ¥ ogsÃ¥ ha argument 'bydel = 1', default er 'indreOslo=0'.
-- bydel = 0: Uten bydel fÃ¥r hele kommune 301 Oslo bohf=30 (Oslo), ved bruk av 'bydel=1' deles kommune 301 Oslo til bohf: 15 (akershus), 17 (lovisenberg), 18 (diakonhjemmet) og 15 (ahus), default er 'bydel=1'. 
+- inndata: Datasett som skal få koblet på bo-variablene.
+- indreOslo = 1: Slår sammen Diakonhjemmet og Lovisenberg, NB: må også ha argument 'bydel = 1', default er 'indreOslo=0'.
+- bydel = 0: Uten bydel får hele kommune 301 Oslo bohf=30 (Oslo), ved bruk av 'bydel=1' deles kommune 301 Oslo til bohf: 15 (akershus), 17 (lovisenberg), 18 (diakonhjemmet) og 15 (ahus), default er 'bydel=1'. 
 
 ### Output 
 - bo-variablene: boshhn, bohf, borhf og fylke.
@@ -21,6 +21,7 @@ Bo-variablene defineres ved Ã¥ bruke 'komnr' og 'bydel' fra inndata.
 - 2020 Opprettet av Tove og Janice
 - september 2021, Tove, fjernet argument 'utdata='
 - januar 2022, Tove, fjerne argument 'barn=' og 'haraldsplass='
+- februar 2022, Tove, ta ut radene som kun brukes til formater
  */
 
 /*
@@ -28,14 +29,14 @@ Bo-variablene defineres ved Ã¥ bruke 'komnr' og 'bydel' fra inndata.
 1. Drop variablene BOHF, BORHF og BOSHHN
 *****************************************
 */
-/* Pga sql-merge i makroen mÃ¥ datasettet en sender inn ikke ha variablene bohf, borhf eller boshhn med */
+/* Pga sql-merge i makroen må datasettet en sender inn ikke ha variablene bohf, borhf eller boshhn med */
 data &inndata;
 set &inndata;
 drop bohf borhf boshhn;
 run;
 /*
 *********************************************
-2. Importere CSV-fil med mapping av boomrÃ¥der
+2. Importere CSV-fil med mapping av boområder
 *********************************************
 */
 data bo;
@@ -57,10 +58,11 @@ data bo;
  
   input	
   komnr komnr_navn $ bydel bydel_navn $ bohf bohf_navn $ boshhn boshhn_navn $ borhf borhf_navn $ kommentar $ ;
+  if komnr eq . then delete; /*ta vekk rader som kun brukes til å lage formater*/
   run;
 /*
 *********************************
-3a. Bo - OpptaksomrÃ¥der med bydel
+3a. Bo - Opptaksområder med bydel
 *********************************
 */
 %if &bydel = 1 %then %do;
@@ -79,7 +81,7 @@ run;
 %end;
 /*
 **********************************
-3b. Bo - OpptaksomrÃ¥der uten bydel
+3b. Bo - Opptaksområder uten bydel
 **********************************
 */
 %if &bydel = 0 %then %do;
@@ -107,7 +109,7 @@ run;
 */
 data &inndata;
 set &inndata;
-%if &indreoslo = 1 %then %do; /* SlÃ¥r sammen Lovisenberg og Diakonhjemmet */
+%if &indreoslo = 1 %then %do; /* Slår sammen Lovisenberg og Diakonhjemmet */
   if bohf in (17,18) then bohf=31;
 %end;
 /*


### PR DESCRIPTION
Blir feil når boomraader kjøres på kpr-data pga rader i kpr-data som har verdier som brukes til formatene (f.eks 7777,8888,99,24,31).