### PR TITLE
tilrettelegging av prosedyrekoder

### DIFF
--- a/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas
@@ -1,0 +1,26 @@
+%macro nc_koder(inndata=, xp=);
+data &inndata;
+set &inndata;
+/* finne ut hvor mange ncsp-variabler som sendes inn */
+array nc&xp._mottatt{*} $ nc&xp._: ;
+	do i= 1 to dim(nc&xp._mottatt) ;
+	end;
+nkode=max(i)-1;
+run;
+/* lage makrovariabel som angir antall ncsp-variabler */
+proc sql noprint;
+	select nkode into: ant_n
+	from &inndata;
+quit;
+%let ant_nc = &ant_n;
+/* lage ny ncsp-variabler med store bokstaver og mellomrom fjernes */
+data &inndata;
+set &inndata;
+array nc&xp._org{*} $ nc&xp._: ;
+array nc&xp._ny{*} $ nc&xp.1-nc&xp.&ant_nc;
+ 	do j= 1 to dim(nc&xp._org) ;
+   nc&xp._ny{j}=upcase(compress(nc&xp._org{j}));
+end;
+drop nc&xp._: j i nkode ;
+run;
+%mend nc_koder;

--- a/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas
@@ -1,4 +1,4 @@
-%macro nc_koder(inndata=, xp=);
+﻿%macro nc_koder(inndata=, xp=);
 data &inndata;
 set &inndata;
 /* finne ut hvor mange ncsp-variabler som sendes inn */
@@ -9,10 +9,10 @@ nkode=max(i)-1;
 run;
 /* lage makrovariabel som angir antall ncsp-variabler */
 proc sql noprint;
-	select nkode into: ant_n
+	select nkode into: ant_nc trimmed
 	from &inndata;
 quit;
-%let ant_nc = &ant_n;
+
 /* lage ny ncsp-variabler med store bokstaver og mellomrom fjernes */
 data &inndata;
 set &inndata;

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -5,6 +5,9 @@ data _null_;
 dset=open("&inndata");
 call symput ('komnrhjem2',varnum(dset,'komnrhjem2'));
 call symput ('bydel2',varnum(dset,'bydel2'));
+call symput ('ncmp_1',varnum(dset,'ncmp_1'));;
+call symput ('ncsp_1',varnum(dset,'ncsp_1'));;
+call symput ('ncrp_1',varnum(dset,'ncrp_1'));;
 run;
 
 data tmp_data;
@@ -33,6 +36,22 @@ run;
 %if &komnrhjem2 ne 0 and &bydel2 ne 0 %then %do;
 %include "&filbane/makroer/boomraader.sas";
 %boomraader(inndata=tmp_data, indreOslo = 0, bydel = 1);
+%end;
+
+/* -------- */
+/* NC-koder */
+/* -------- */
+%if &ncsp_1 ne 0 %then %do; 
+%include "&filbane/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas";
+%nc_koder(inndata=tmp_data, xp=sp);
+%end;
+%if &ncmp_1 ne 0 %then %do; 
+%include "&filbane/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas";
+%nc_koder(inndata=tmp_data, xp=mp);
+%end;
+%if &ncrp_1 ne 0 %then %do; 
+%include "&filbane/tilrettelegging/npr/2_tilrettelegging/nc_koder.sas";
+%nc_koder(inndata=tmp_data, xp=rp);
 %end;
 
 %mend tilrettelegging;


### PR DESCRIPTION
Tilrettelegging av prosedyrekoder. 
Hvis tilretteleggingsmakro finner ncmp_1, ncsp_1 eller ncrp_1, så kjøres kode for tilrettelegging av variablene. 
Hvor mange nc-koder det lages avhenger av antall i datasettet. Rehabdata har f.eks kun 10.

Kjører upcase og compress på nc-variablene. 
Kom gjerne med innspill. 