### PR TITLE
Endre rekkefølge makro pga følgeeffekt

### DIFF
--- a/tilrettelegging/npr/2_tilrettelegging/def_aspes_kontakt.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/def_aspes_kontakt.sas
@@ -36,7 +36,7 @@ Data &utdata;
 	*initialize variable;
 	kontakt_def=0;
 
-	Array Normaltariff (15) Normaltariff:;
+	Array Normaltariff (15) takst_: ;
 
 	do i=1 to 15;
 	  Normaltariff(i)=lowcase(Normaltariff(i));

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -241,11 +241,11 @@ run;
 /* Takst    */
 /* -------- */
 %if &takst_1 ne 0 and &aspes=1 %then %do; 
-%include "&filbane/tilrettelegging/npr/2_tilrettelegging/takst.sas";
-%takst(inndata=tmp_data);
-
 %include "&filbane/tilrettelegging/npr/2_tilrettelegging/def_aspes_kontakt.sas";
 %def_aspes_kontakt(inndata=tmp_data, utdata=tmp_data);
+
+%include "&filbane/tilrettelegging/npr/2_tilrettelegging/takst.sas";
+%takst(inndata=tmp_data);
 %end;
 
 /* ----------- */


### PR DESCRIPTION
Når makro %def_aspes_kontakt ble kjørt ble tilrettelegging av normaltariff-variablene endret. Det ble gjort om til lowcase i stedet for propcase. 
Kjører nå def_aspes_kontakt først, slik at normaltariff-variablene beholder propcase, dvs stor bokstav først. 