### PR TITLE
drop variabel døddato fra tilrettelagte filer

### DIFF
--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -29,6 +29,7 @@ call symput ('fag',varnum(dset,'fag'));
 call symput ('fagenhetkode',varnum(dset,'fagenhetkode'));
 call symput ('fagomrade',varnum(dset,'fagomrade'));
 call symput ('tilst1akse1',varnum(dset,'tilst1akse1'));
+call symput ('doddato',varnum(dset,'doddato'));
 run;
 
 %include "&filbane/formater/SKDE_somatikk.sas";
@@ -324,6 +325,17 @@ run;
 
 %include "&filbane/tilrettelegging/npr/2_tilrettelegging/length_label.sas";
 %length_label(inndata=tmp_data)
+
+/* --------------------- */
+/* Drop variabel døddato */
+/* --------------------- */
+/* variabel utleveres årlig som egen fil sammen med T3-utlevering */
+%if &doddato ne 0 %then %do;
+data tmp_data;
+set tmp_data;
+drop doddato;
+run;
+%end;
 
 /* ---------------------- */
 /* Drop i phbu og phv_rus */


### PR DESCRIPTION
Døddato utleveres i egen fil, utleveres sammen med T3-data.
I tillegg ligger døddato i utleverte filer, men den har ikke oppdaterte verdier utover tidspunktet data ble utlevert. 
Den enkelte må koble på oppdatert døddato selv ved bruk av egen fil.
Fjerner derfor variabel "doddato" fra tilrettelagt fil slik at utlevert variabel i data som ikke er oppdatert ikke brukes ved feiltakelse.