### PR TITLE
drop av variabler behsh, behhf og behrhf

### DIFF
--- a/tilrettelegging/npr/2_tilrettelegging/behandler.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/behandler.sas
@@ -74,8 +74,10 @@ set beh;
 run;
 
 /* hvis behandlingsstedkode mangler i datasettet så brukes institusjonid */
+/* gjør en drop av variablene som skal legges til. Left join vil ikke fungere hvis variablene allerede eksisterer. */
 data &inndata;
 set &inndata;
+drop=behsh behhf behrhf;
 if &beh = . then &beh = institusjonid;
 run;
 


### PR DESCRIPTION
Gjøre drop av variablene behsh, behhf og behrhf i tilfelle de allerede er i filen.
Variablene vil ikke oppdateres hvis de allerede er i filen. 