### PR TITLE
create new aggrshopp that is unique

### DIFF
--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -30,6 +30,7 @@ call symput ('fagenhetkode',varnum(dset,'fagenhetkode'));
 call symput ('fagomrade',varnum(dset,'fagomrade'));
 call symput ('tilst1akse1',varnum(dset,'tilst1akse1'));
 call symput ('doddato',varnum(dset,'doddato'));
+call symput ('aggrshoppID_Lnr',varnum(dset,'aggrshoppID_Lnr'));
 run;
 
 %include "&filbane/formater/SKDE_somatikk.sas";
@@ -43,8 +44,8 @@ proc sql noprint;
 quit;
 %end;
 
-data tmp_data;
-set &inndata;
+data tmp_data(drop=aggrshoppID_Lnr_orig);
+set &inndata(rename=(aggrshoppID_Lnr=aggrshoppID_Lnr_orig));
 
 /*-----*/
 /* PID */
@@ -52,6 +53,25 @@ set &inndata;
 %if &lopenr ne 0 %then %do;
 pid=lopenr;
 drop lopenr;
+%end;
+
+/*---------------  */
+/* AGGRSHOPPID_LNR */
+/*---------------  */
+
+%if &aggrshoppID_Lnr ne 0 %then %do;
+if aggrshoppID_Lnr_orig in (.,1) then aggrshoppID_Lnr=1;
+
+if aggrshoppID_Lnr_orig ne 1 then do;
+
+  /* Calculate the length of aggrshoppID_Lnr dynamically */
+  length_aggrshopp = ceil(log10(aggrshoppID_Lnr_orig + 1)); /* Add 1 to handle cases where aggrshoppID_Lnr is 0 or . */
+  
+  /* Combine the two numbers into a single numeric value */
+  aggrshoppID_Lnr = pid * (10**length_aggrshopp) + aggrshoppID_Lnr_orig;
+
+end;
+format aggrshoppID_Lnr 20.;
 %end;
 
 /*-----*/

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -229,10 +229,11 @@ proc sql noprint;
 quit;
 %end;
 
+%if &aspes eq 1 %then %do;
+
 data tmp_data;
 set tmp_data;
 
-%if &aspes eq 1 %then %do;
 hastegrad = 4;
 utdato=inndato;
 
@@ -264,8 +265,8 @@ drop sh_reg;
     if Fag = 30 then Fag_SKDE = 30;
     if Fag = 31 then Fag_SKDE = 31;
 %end;
-%end;
 run;
+%end;
 
 /*---------------*/
 /* Tilstandkoder */

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -179,6 +179,8 @@ run;
 /* AGGRSHOPPID_LNR */
 /*-----------------*/
 
+%if &aggrshoppID_Lnr ne 0 %then %do;
+
 title 'number of unique aggrshopp BEFORE';
 proc sql;
   select count(distinct aggrshoppID_Lnr) as n_aggr format nlnum8.0,
@@ -214,6 +216,7 @@ proc sql;
   from tmp_data
   where aggrshoppID_Lnr ne 1;
 quit;
+%end;
 
 /*---------*/
 /* AVTSPES */

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -44,8 +44,8 @@ proc sql noprint;
 quit;
 %end;
 
-data tmp_data(drop=aggrshoppID_Lnr_orig);
-set &inndata(rename=(aggrshoppID_Lnr=aggrshoppID_Lnr_orig));
+data tmp_data;
+set &inndata;
 
 /*-----*/
 /* PID */
@@ -53,25 +53,6 @@ set &inndata(rename=(aggrshoppID_Lnr=aggrshoppID_Lnr_orig));
 %if &lopenr ne 0 %then %do;
 pid=lopenr;
 drop lopenr;
-%end;
-
-/*---------------  */
-/* AGGRSHOPPID_LNR */
-/*---------------  */
-
-%if &aggrshoppID_Lnr ne 0 %then %do;
-if aggrshoppID_Lnr_orig in (.,1) then aggrshoppID_Lnr=1;
-
-if aggrshoppID_Lnr_orig ne 1 then do;
-
-  /* Calculate the length of aggrshoppID_Lnr dynamically */
-  length_aggrshopp = ceil(log10(aggrshoppID_Lnr_orig + 1)); /* Add 1 to handle cases where aggrshoppID_Lnr is 0 or . */
-  
-  /* Combine the two numbers into a single numeric value */
-  aggrshoppID_Lnr = pid * (10**length_aggrshopp) + aggrshoppID_Lnr_orig;
-
-end;
-format aggrshoppID_Lnr 20.;
 %end;
 
 /*-----*/
@@ -192,6 +173,27 @@ format ny_sektor fmt_sektor.;
 rename ny_sektor = sektor;
 drop inn_sektor; 
 %end;  
+run;
+
+/*-----------------*/
+/* AGGRSHOPPID_LNR */
+/*-----------------*/
+
+proc sort data=tmp_data;
+    by pid aggrshoppID_Lnr;
+run;
+
+data tmp_data(drop=tmp aggrshoppID_Lnr rename=(aggrshoppID_Lnr2=aggrshoppID_Lnr));
+    set tmp_data;
+    
+    by pid aggrshoppID_Lnr;
+    retain tmp 0;
+
+    if aggrshoppID_Lnr = 1 then aggrshoppID_Lnr2=1;
+    else if first.aggrshoppID_Lnr then do;
+	    tmp+1;
+  	    aggrshoppID_Lnr2=aar*1000000+tmp;
+    end;
 run;
 
 %if &sektor ne 0 %then %do;

--- a/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
+++ b/tilrettelegging/npr/2_tilrettelegging/tilrettelegging.sas
@@ -179,6 +179,14 @@ run;
 /* AGGRSHOPPID_LNR */
 /*-----------------*/
 
+title 'number of unique aggrshopp BEFORE';
+proc sql;
+  select count(distinct aggrshoppID_Lnr) as n_aggr format nlnum8.0,
+         count(distinct catx('-', pid, aggrshoppID_Lnr)) as n_pid_aggr format nlnum8.0
+  from tmp_data
+  where aggrshoppID_Lnr ne 1;
+quit;
+
 proc sort data=tmp_data;
     by pid aggrshoppID_Lnr;
 run;
@@ -189,12 +197,27 @@ data tmp_data(drop=tmp aggrshoppID_Lnr rename=(aggrshoppID_Lnr2=aggrshoppID_Lnr)
     by pid aggrshoppID_Lnr;
     retain tmp 0;
 
-    if aggrshoppID_Lnr = 1 then aggrshoppID_Lnr2=1;
-    else if first.aggrshoppID_Lnr then do;
+	/* assign a tmp number to each time there is a new aggrshopp that is not 1 */
+    if first.aggrshoppID_Lnr and aggrshoppID_Lnr ne 1 then do;
 	    tmp+1;
-  	    aggrshoppID_Lnr2=aar*1000000+tmp;
     end;
+
+	/* combine aar and tmp to create the new aggrshopp, default 1s back to 1 */
+  	aggrshoppID_Lnr2=aar*1000000+tmp;
+    if aggrshoppID_Lnr = 1 then aggrshoppID_Lnr2=1;
 run;
+
+title 'number of unique aggrshopp AFTER';
+proc sql;
+  select count(distinct aggrshoppID_Lnr) as n_aggr format nlnum8.0,
+         count(distinct catx('-', pid, aggrshoppID_Lnr)) as n_pid_aggr format nlnum8.0
+  from tmp_data
+  where aggrshoppID_Lnr ne 1;
+quit;
+
+/*---------*/
+/* AVTSPES */
+/*---------*/
 
 %if &sektor ne 0 %then %do;
 proc sql noprint;
@@ -203,9 +226,6 @@ proc sql noprint;
 quit;
 %end;
 
-/*---------*/
-/* AVTSPES */
-/*---------*/
 data tmp_data;
 set tmp_data;
 


### PR DESCRIPTION
Starting 2024, the variable aggrshoppID_lnr is not unique across different pid.  Create a new version of this varaible, combining pid and aggrshoppID_lnr so that it is unique (i.e. a given aggrshoppID can only exist for one pid).